### PR TITLE
fix redis host name not picked up on config

### DIFF
--- a/src/backend/DocDownloaderRedisCache/src/main/java/ca/bc/gov/ag/courts/config/RedisConfig.java
+++ b/src/backend/DocDownloaderRedisCache/src/main/java/ca/bc/gov/ag/courts/config/RedisConfig.java
@@ -5,6 +5,7 @@ import ca.bc.gov.ag.courts.queue.RedisMessagePublisher;
 import ca.bc.gov.ag.courts.queue.RedisMessageSubscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -25,6 +26,15 @@ public class RedisConfig {
 
     Logger logger = LoggerFactory.getLogger(RedisConfig.class);
 
+    private String host;
+    private Integer port;
+
+    public RedisConfig(@Value("${spring.redis.host}") String host, @Value("${spring.redis.port}") int port) {
+        logger.info("RedisConfig starting url: " + host + " port: " + port);
+        this.host = host;
+        this.port = port;
+    }
+
     @Bean
     JedisConnectionFactory jedisConnectionFactory() {
         return new JedisConnectionFactory();
@@ -33,7 +43,8 @@ public class RedisConfig {
     @Bean
     public RedisTemplate<String, Object> redisTemplate() {
         final RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(jedisConnectionFactory());
+        jedisConnectionFactory().setHostName(host);
+        jedisConnectionFactory().setPort(port);
         template.setValueSerializer(new GenericToStringSerializer<>(Object.class));
         template.setEnableTransactionSupport(true);
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):
Env config for the Redis connection is not picking up values from the env so added class level configuration to make sure the values are set from the env not the prop file.

- {List all the changes, if possible add the jira ticket #} https://justice.gov.bc.ca/jira/browse/SCV-425

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes